### PR TITLE
Upgrade to Next.js v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@types/node": "20.2.5",
-    "@types/react": "18.2.8",
-    "@types/react-dom": "18.2.4",
-    "autoprefixer": "10.4.14",
-    "eslint": "8.42.0",
-    "eslint-config-next": "13.4.4",
-    "next": "13.4.4",
-    "postcss": "8.4.24",
+    "@types/node": "20.2.6",
+    "@types/react": "18.2.9",
+    "@types/react-dom": "18.2.5",
+    "autoprefixer": "10.4.15",
+    "eslint": "8.42.1",
+    "eslint-config-next": "14.0.0",
+    "next": "14.0.0",
+    "postcss": "8.4.25",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwindcss": "3.3.2",
-    "typescript": "5.1.3"
+    "tailwindcss": "3.3.3",
+    "typescript": "5.1.4"
   }
 }


### PR DESCRIPTION
Updates the website to use Next.js version 14 and bumps other dependencies to their latest versions.

- **Next.js Upgrade**: Upgrades `next` from `13.4.4` to `14.0.0` to revamp the website with the latest features and improvements of Next.js version 14.
- **Dependency Updates**: Bumps versions of several dependencies including `@types/node`, `@types/react`, `@types/react-dom`, `autoprefixer`, `eslint`, `eslint-config-next`, `postcss`, `tailwindcss`, and `typescript` to their latest minor or patch versions. This ensures compatibility with Next.js 14 and brings in the latest fixes and improvements from these libraries.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alphaolomi/alphaolomi.github.io?shareId=1cc847ad-3662-452c-be16-a985be11fb76).